### PR TITLE
Limit relative humidity

### DIFF
--- a/adafruit_si7021.py
+++ b/adafruit_si7021.py
@@ -129,7 +129,7 @@ class SI7021:
         self.start_measurement(HUMIDITY)
         value = self._data()
         self._measurement = 0
-        return value * 125.0 / 65536.0 - 6.0
+        return min(100.0, value * 125.0 / 65536.0 - 6.0)
 
     @property
     def temperature(self):


### PR DESCRIPTION
Using non-NIST traceable human breath.

**BEFORE**
```python
Adafruit CircuitPython 4.0.0 on 2019-05-20; Adafruit Metro M4 Airlift Lite with samd51j19
>>> import board
>>> import adafruit_si7021
>>> sensor = adafruit_si7021.SI7021(board.I2C())
>>> sensor.relative_humidity
96.5658
>>> sensor.relative_humidity
100.785
>>> sensor.relative_humidity
101.349
>>> sensor.relative_humidity
102.547
>>> sensor.relative_humidity
103.608
```

**AFTER**
```python
Adafruit CircuitPython 4.0.0 on 2019-05-20; Adafruit Metro M4 Airlift Lite with samd51j19
>>> import board
>>> import adafruit_si7021
>>> sensor = adafruit_si7021.SI7021(board.I2C())
>>> sensor.relative_humidity
98.1145
>>> sensor.relative_humidity
100.0
>>> sensor.relative_humidity
100.0
>>> sensor.relative_humidity
100.0
```