### PR TITLE
use board.I2C() instead of busio in the example script

### DIFF
--- a/examples/si7021_simpletest.py
+++ b/examples/si7021_simpletest.py
@@ -6,9 +6,7 @@ import board
 import adafruit_si7021
 
 # Create library object using our Bus I2C port
-i2c = board.I2C()
-sensor = adafruit_si7021.SI7021(i2c)
-
+sensor = adafruit_si7021.SI7021(board.I2C())
 
 while True:
     print("\nTemperature: %0.1f C" % sensor.temperature)

--- a/examples/si7021_simpletest.py
+++ b/examples/si7021_simpletest.py
@@ -1,10 +1,12 @@
+"""
+Initializes the sensor, gets and prints readings every two seconds.
+"""
 import time
 import board
-import busio
 import adafruit_si7021
 
 # Create library object using our Bus I2C port
-i2c = busio.I2C(board.SCL, board.SDA)
+i2c = board.I2C()
 sensor = adafruit_si7021.SI7021(i2c)
 
 


### PR DESCRIPTION
pylint also complained about missing docstring, so I added that as well.

Tested successfully with `Adafruit CircuitPython 6.1.0-beta.1 on 2020-11-20; MagTag with ESP32S2` and the SI7021 breakout.