### PR TITLE
sleep after reset before read register

### DIFF
--- a/adafruit_si7021/__init__.py
+++ b/adafruit_si7021/__init__.py
@@ -138,7 +138,12 @@ class SI7021:
     def __init__(self, i2c_bus: I2C, address: int = 0x40) -> None:
         self.i2c_device = I2CDevice(i2c_bus, address)
         self._command(_RESET)
+
+        # max 15ms Powerup Time after issuing software reset
+        # Table 2 inside of:
+        # https://cdn-learn.adafruit.com/assets/assets/000/035/931/original/Support_Documents_TechnicalDocs_Si7021-A20.pdf
         time.sleep(0.015)
+
         # Make sure the USER1 settings are correct.
         while True:
             # While restarting, the sensor doesn't respond to reads or writes.

--- a/adafruit_si7021/__init__.py
+++ b/adafruit_si7021/__init__.py
@@ -25,6 +25,7 @@ Implementation Notes
 * Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
 """
 import struct
+import time
 
 from adafruit_bus_device.i2c_device import I2CDevice
 from micropython import const
@@ -137,6 +138,7 @@ class SI7021:
     def __init__(self, i2c_bus: I2C, address: int = 0x40) -> None:
         self.i2c_device = I2CDevice(i2c_bus, address)
         self._command(_RESET)
+        time.sleep(0.015)
         # Make sure the USER1 settings are correct.
         while True:
             # While restarting, the sensor doesn't respond to reads or writes.


### PR DESCRIPTION
resolves #35 

It turns out a sleep of only `0.015` should be the longest that is needed, as specified in the datasheet (Thank you to @KeithTheEE  and @jposada202020 !)

I tested the change successfully on Raspberry Pi 3 B+ w/ Blinka and double checked it on a Feather S2 TFT to ensure the microcontroller behavior still works as expected.